### PR TITLE
Fixing filenames for case-sensitive systems

### DIFF
--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/index.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/index.coffee
@@ -6,8 +6,8 @@
 #= require listReferenceEnhancer
 #= require modelCatalogueApiRoot
 #= require removableItemEnhancer
-#= require modelcatalogueSearch
-#= require modelcatalogueDataArchitect
+#= require modelCatalogueSearch
+#= require modelCatalogueDataArchitect
 
 
 angular.module 'mc.core', [


### PR DESCRIPTION
Fixes #141, typo in filenames for Angular modules. Filenames are case-sensitive, but not on OSX.

This is critical for testing and deployment :).
