### PR TITLE
Promote UUID to all CatalogueElement objects & add UUID API and UI endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # FormsPlugin
 /ModelCatalogueFormsPlugin
 *.iml
-*/web-app/*
-*/.idea/*
+**/web-app/*
+**/.idea/*
+**/atlassian-ide-plugin.xml

--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/catalogueElementResource.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/catalogueElementResource.coffee
@@ -9,6 +9,9 @@ angular.module('mc.core.catalogueElementResource', ['mc.core.modelCatalogueApiRo
       getIndexPath: () ->
         "#{modelCatalogueApiRoot}/#{@pathName}"
 
+      getByUUID: (uuid) ->
+        enhance rest method: 'GET', url: "#{@getIndexPath()}/uuid/#{uuid}"
+
       get: (id) ->
         enhance rest method: 'GET', url: "#{@getIndexPath()}/#{id}"
 

--- a/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/states/defaultStates.coffee
+++ b/ModelCatalogueCorePlugin/grails-app/assets/javascripts/modelcatalogue/core/ui/states/defaultStates.coffee
@@ -115,6 +115,19 @@ angular.module('mc.core.ui.states.defaultStates', ['ui.router'])
     controller: 'mc.core.ui.states.ShowCtrl'
   }
 
+  $stateProvider.state 'mc.resource.uuid', {
+    url: '/uuid/:uuid'
+
+    templateUrl: 'modelcatalogue/core/ui/state/show.html'
+
+    resolve:
+      element: ['$stateParams','catalogueElementResource', ($stateParams, catalogueElementResource) ->
+        catalogueElementResource($stateParams.resource).getByUUID($stateParams.uuid)
+      ]
+
+    controller: 'mc.core.ui.states.ShowCtrl'
+  }
+
   $stateProvider.state 'mc.resource.show.property', {url: '/:property?page'}
 
   $stateProvider.state('mc.search', {

--- a/ModelCatalogueCorePlugin/grails-app/conf/ModelCatalogueCorePluginUrlMappings.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/conf/ModelCatalogueCorePluginUrlMappings.groovy
@@ -11,6 +11,7 @@ class ModelCatalogueCorePluginUrlMappings {
         for (String controllerName in allElements) {
             "/api/modelCatalogue/core/$controllerName" (controller: controllerName, action: 'index', method: HttpMethod.GET)
             "/api/modelCatalogue/core/$controllerName" (controller: controllerName, action: 'save', method: HttpMethod.POST)
+			"/api/modelCatalogue/core/$controllerName/uuid/$uuid" (controller: controllerName, action: 'uuid', method: HttpMethod.GET)
             "/api/modelCatalogue/core/$controllerName/search/$search?" (controller: controllerName, action: 'search', method: HttpMethod.GET)
             "/api/modelCatalogue/core/$controllerName/$id/validate" (controller: controllerName, action: 'validate', method: HttpMethod.POST)
             "/api/modelCatalogue/core/$controllerName/validate" (controller: controllerName, action: 'validate', method: HttpMethod.POST)

--- a/ModelCatalogueCorePlugin/grails-app/controllers/org/modelcatalogue/core/AbstractCatalogueElementController.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/controllers/org/modelcatalogue/core/AbstractCatalogueElementController.groovy
@@ -15,6 +15,10 @@ abstract class AbstractCatalogueElementController<T> extends AbstractRestfulCont
     def relationshipService
     def mappingService
 
+	def uuid(String uuid){
+		respond resource.findByModelCatalogueId(uuid)
+	}
+
     AbstractCatalogueElementController(Class<T> resource, boolean readOnly) {
         super(resource, readOnly)
     }

--- a/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/CatalogueElement.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/CatalogueElement.groovy
@@ -17,6 +17,7 @@ abstract class CatalogueElement {
 
     String name
     String description
+	String modelCatalogueId = "MC_" + UUID.randomUUID() + "_" + 1
 
     static transients = ['relations', 'info', 'archived', 'incomingRelations', 'outgoingRelations']
 
@@ -29,11 +30,13 @@ abstract class CatalogueElement {
     static constraints = {
         name size: 1..255
         description nullable: true, maxSize: 2000
+		modelCatalogueId nullable: true, unique: true, maxSize: 255, matches: '(?i)MC_([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12})_\\d+'
     }
 
     //WIP gormElasticSearch will support aliases in the future for now we will use searchable
 
     static searchable = {
+		modelCatalogueId boost:10
         name boost:5
         incomingMappings component: true
         except = ['incomingRelationships', 'outgoingRelationships', 'incomingMappings', 'outgoingMappings']
@@ -143,7 +146,7 @@ abstract class CatalogueElement {
     }
 
     String toString() {
-        "${getClass().simpleName}[id: ${getId()}, name: ${getName()}]"
+        "${getClass().simpleName}[id: ${getId()}, name: ${getName()}, modelCatalogueId: ${modelCatalogueId}]"
     }
 
     Map<String, Object> getInfo() {
@@ -174,4 +177,19 @@ abstract class CatalogueElement {
             mapping.delete(flush:true)
         }
     }
+
+	def updateModelCatalogueId() {
+		def newCatalogueId = modelCatalogueId.split("_")
+		newCatalogueId[-1] = newCatalogueId.last().toInteger() + 1
+		modelCatalogueId = newCatalogueId.join("_")
+	}
+
+	/**
+	 * Get the Model Catalogue ID excluding any version information suffix.
+	 * @return The model catalogue ID, minus any trailing underscore and version numbers
+	 */
+	def getBareModelCatalogueId() {
+		// Match everything from the ID except the final underscore and integers ('_\d+')
+		(modelCatalogueId =~ /(?i)(MC_([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}))/)[0][1]
+	}
 }

--- a/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/PublishedElement.groovy
+++ b/ModelCatalogueCorePlugin/grails-app/domain/org/modelcatalogue/core/PublishedElement.groovy
@@ -3,8 +3,6 @@ package org.modelcatalogue.core
 abstract class PublishedElement extends CatalogueElement {
 
     //version number - this gets iterated every time a new version is created from a finalized version
-
-    String modelCatalogueId
     Integer versionNumber = 1
 
     //status: once an object is finalized it cannot be changed
@@ -14,7 +12,6 @@ abstract class PublishedElement extends CatalogueElement {
     PublishedElementStatus status = PublishedElementStatus.DRAFT
 
     static searchable = {
-        modelCatalogueId boost:10
         except = ['versionNumber']
     }
 
@@ -24,7 +21,6 @@ abstract class PublishedElement extends CatalogueElement {
         !status.modificable
     }
     static constraints = {
-        modelCatalogueId nullable:true, unique:true, maxSize: 255, matches: '(?i)MC_([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12})_\\d+'
 //        TODO we need to think about what restrictions we put on publishing elements
 //        status validator: { val , obj->
 //            if(!val){ return true}
@@ -46,33 +42,6 @@ abstract class PublishedElement extends CatalogueElement {
 
     String toString() {
         "${getClass().simpleName}[id: ${id}, name: ${name}, version: ${version}, status: ${status}, modelCatalogueId: ${modelCatalogueId}]"
-    }
-
-    def afterInsert(){
-        if(!getModelCatalogueId()) {
-            createModelCatalogueId()
-        }
-    }
-
-    def createModelCatalogueId(){
-        modelCatalogueId = "MC_" + UUID.randomUUID() + "_" + 1
-    }
-
-
-    def updateModelCatalogueId() {
-        if(getModelCatalogueId()) {
-            def newCatalogueId = modelCatalogueId.split("_")
-            newCatalogueId[-1] = newCatalogueId.last().toInteger() + 1
-            modelCatalogueId = newCatalogueId.join("_")
-        }else{
-            createModelCatalogueId()
-        }
-    }
-
-
-    def getBareModelCatalogueId() {
-        afterInsert()
-        (modelCatalogueId =~ /(?i)(MC_([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}))/)[0][1]
     }
 
     Integer countVersions() {

--- a/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/util/marshalling/CatalogueElementMarshallers.groovy
+++ b/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/util/marshalling/CatalogueElementMarshallers.groovy
@@ -24,6 +24,7 @@ abstract class CatalogueElementMarshallers extends AbstractMarshallers {
         if (!el) return [:]
         def ret = [
                 id: el.id,
+				modelCatalogueId: el.modelCatalogueId,
                 archived: el.archived,
                 name: el.name,
                 description: el.description,
@@ -87,6 +88,7 @@ abstract class CatalogueElementMarshallers extends AbstractMarshallers {
 
     protected void addXmlAttributes(el, XML xml) {
         addXmlAttribute(el.id, "id", xml)
+		addXmlAttribute(el.modelCatalogueId, "modelCatalogueId", xml)
         addXmlAttribute(el.archived, "archived", xml)
         addXmlAttribute(el.version, "version", xml)
         addXmlAttribute("/${GrailsNameUtils.getPropertyName(el.getClass())}/$el.id", "link", xml)

--- a/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/util/marshalling/PublishedElementMarshallers.groovy
+++ b/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/util/marshalling/PublishedElementMarshallers.groovy
@@ -19,7 +19,6 @@ abstract class PublishedElementMarshallers extends CatalogueElementMarshallers {
         ret.putAll(
                 versionNumber: el.versionNumber,
                 status: el.status.toString(),
-                modelCatalogueId: el.modelCatalogueId,
                 history: [count: el.countVersions(), itemType: type.name, link: "/${GrailsNameUtils.getPropertyName(el.getClass())}/$el.id/history"]
         )
         ret
@@ -30,6 +29,5 @@ abstract class PublishedElementMarshallers extends CatalogueElementMarshallers {
         super.addXmlAttributes(el, xml)
         addXmlAttribute(el.versionNumber, "versionNumber", xml)
         addXmlAttribute(el.status, "status", xml)
-        addXmlAttribute(el.modelCatalogueId, "modelCatalogueId", xml)
     }
 }

--- a/ModelCatalogueCorePlugin/test/unit/org/modelcatalogue/core/ConceptualDomainSpec.groovy
+++ b/ModelCatalogueCorePlugin/test/unit/org/modelcatalogue/core/ConceptualDomainSpec.groovy
@@ -20,7 +20,7 @@ class ConceptualDomainSpec extends Specification {
         ConceptualDomain.list().isEmpty()
 
         when:
-
+		args.modelCatalogueId = "MC_" + UUID.randomUUID() + "_1"
         def conceptInstance = new ConceptualDomain(args)
 
         conceptInstance.save()

--- a/ModelCatalogueCorePlugin/test/unit/org/modelcatalogue/core/PublishedElementSpec.groovy
+++ b/ModelCatalogueCorePlugin/test/unit/org/modelcatalogue/core/PublishedElementSpec.groovy
@@ -6,14 +6,21 @@ class PublishedElementSpec extends Specification {
 
 
     def "get bare model catalogue id"() {
+
+		when:
         PublishedElement el = new Model()
         el.id = 15
-        el.updateModelCatalogueId()
 
+		then:
+		el.modelCatalogueId.endsWith("_1")
+		el.bareModelCatalogueId == el.modelCatalogueId.replaceAll('_1$', '')
 
-        expect:
-        el.modelCatalogueId.endsWith("_1")
-        el.bareModelCatalogueId == el.modelCatalogueId.replaceAll('_1$', '')
+		when:
+		el.updateModelCatalogueId()
+
+        then:
+        el.modelCatalogueId.endsWith("_2")
+        el.bareModelCatalogueId == el.modelCatalogueId.replaceAll('_2$', '')
 
     }
 


### PR DESCRIPTION
This PR adds a UUID endpoint to the UI, e.g.:

`#/catalogue/model/uuid/MC_00a2ef83-e057-4958-ab3e-b4e4995ecc43_1`

It also adds an endpoint to the API which allows CatalogueElements to be queried by UUID, e.g.:

`/core/model/uuid/MC_00a2ef83-e057-4958-ab3e-b4e4995ecc43_1`

The above gets applied to all CatalogueElements, so `model` above can be replaced for any other API-accessible class...

To achieve this UUID has been extracted to from PublishedElement and promoted to CatalogueElement (because all controllers, etc. use this as the abstract base). See the commit messages for more info.

Fixes MC-287.
