### PR TITLE
MET-1199 custom prefix for elasticsearch indicies

### DIFF
--- a/ModelCatalogueElasticSearchPlugin/grails-app/services/org/modelcatalogue/core/elasticsearch/ElasticSearchService.groovy
+++ b/ModelCatalogueElasticSearchPlugin/grails-app/services/org/modelcatalogue/core/elasticsearch/ElasticSearchService.groovy
@@ -65,7 +65,9 @@ class ElasticSearchService implements SearchCatalogue {
         return ret
     }
 
-    private static final String MC_PREFIX = "mc_"
+    private static final String ENV_MC_ES_PREFIX = 'MC_INDEX_PREFIX'
+
+    private static final String MC_PREFIX = "${System.getenv(ENV_MC_ES_PREFIX) ?: ''}mc_"
     private static final String GLOBAL_PREFIX = "${MC_PREFIX}global_"
     private static final String MC_ALL_INDEX = "${MC_PREFIX}all"
     private static final String DATA_MODEL_INDEX = "${GLOBAL_PREFIX}data_model"
@@ -114,7 +116,6 @@ class ElasticSearchService implements SearchCatalogue {
                           .local(true).node()
 
         client = node.client()
-
         log.info "Using local ElasticSearch instance in directory ${grailsApplication.config.mc.search.elasticsearch.local}"
     }
 

--- a/docs/deployment/environment.adoc
+++ b/docs/deployment/environment.adoc
@@ -146,6 +146,12 @@ uses local H2 database if not set as `"${System.properties['catalina.base']}/db"
 |Set automatically if running with `docker-compose` or uses local embedded instance if not set
 at `"${System.properties['catalina.base']}/es"`
 
+|Search
+|`MC_ES_PREFIX`
+|Prefix of the indicies for current application (useful for shared Elasticsearch servers)
+|_None_
+
+
 |Mail
 |`MC_MAIL_FROM`
 |Default mail sender for the application


### PR DESCRIPTION
so multiple servers can run against single es instance