### PR TITLE
MET-1321 duplicate items are created if the items are inherited

### DIFF
--- a/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/publishing/CopyAssociationsAndRelationships.groovy
+++ b/ModelCatalogueCorePlugin/src/groovy/org/modelcatalogue/core/publishing/CopyAssociationsAndRelationships.groovy
@@ -82,7 +82,7 @@ class CopyAssociationsAndRelationships {
                 return
             }
 
-            if (r.archived) {
+            if (r.archived || r.inherited) {
                 return
             }
 


### PR DESCRIPTION
when new draft is created