### PR TITLE
using unknown count for data elements and data types

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/DataModelController.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/DataModelController.groovy
@@ -109,11 +109,9 @@ class DataModelController extends AbstractCatalogueElementController<DataModel> 
         ListWithTotalAndType<Map> list = Lists.lazy(params, Map) {
             List<Map> contentDescriptors = []
 
-            boolean isMysql = sessionFactory.currentSession.connection().metaData.databaseProductName == 'MySQL'
-
             contentDescriptors << createContentDescriptor(dataModel, 'Data Classes', DataClass, dataClasses.total)
-            contentDescriptors << createContentDescriptor(dataModel, 'Data Elements', DataElement, isMysql ? dataElementService.findAllDataElementsInModel([:], dataModel).total : stats["totalDataElementCount"])
-            contentDescriptors << createContentDescriptor(dataModel, 'Data Types', DataType, isMysql ? dataTypeService.findAllDataTypesInModel([:], dataModel).total : stats["totalDataTypeCount"])
+            contentDescriptors << createContentDescriptor(dataModel, 'Data Elements', DataElement, Integer.MAX_VALUE)
+            contentDescriptors << createContentDescriptor(dataModel, 'Data Types', DataType, Integer.MAX_VALUE)
             contentDescriptors << createContentDescriptor(dataModel, 'Measurement Units', MeasurementUnit, stats["totalMeasurementUnitCount"])
             contentDescriptors << createContentDescriptor(dataModel, 'Business Rules', ValidationRule, stats["totalValidationRuleCount"])
             contentDescriptors << createContentDescriptor(dataModel, 'Assets', Asset, stats["totalAssetCount"])


### PR DESCRIPTION
as the computation takes very long time at the moment.

this speeds up initial load of data model and keeps the possibility to display all used data elements and data types even for very deep data models (having transitive dependencies to HPO)