### PR TITLE
allow repetition in xml exports where possible

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/states/controllers/XMLEditorCtrl.coffee
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/states/controllers/XMLEditorCtrl.coffee
@@ -31,7 +31,7 @@ angular.module('mc.core.ui.states.controllers.XmlEditorCtrl', ['ui.ace', 'ngFile
         , 500
         )
 
-    $http.get("#{element.internalModelCatalogueId}?format=xml&full=true").then (resp) ->
+    $http.get("#{element.internalModelCatalogueId}?format=xml&full=true&repetitive=true").then (resp) ->
       $scope.xml = resp.data
 
     $http.get("#{security.contextPath}#{catalogue.getDefaultXslt(element.elementType) ? catalogue.getDefaultXslt('catalogueElement')}").then (resp) ->

--- a/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/CatalogueController.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/CatalogueController.groovy
@@ -39,6 +39,9 @@ class CatalogueController {
                 if (params.full != 'true') {
                     keepInside = element.instanceOf(DataModel) ? element : element.dataModel
                 }
+                if (params.repetitive == 'true') {
+                    repetitive = true
+                }
             }.writeTo(response.writer)
             return
         }

--- a/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/CatalogueController.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/controllers/org/modelcatalogue/core/CatalogueController.groovy
@@ -77,6 +77,9 @@ class CatalogueController {
                 if (params.full != 'true') {
                     keepInside = element.instanceOf(DataModel) ? element : element.dataModel
                 }
+                if (params.repetitive == 'true') {
+                    repetitive = true
+                }
             }.writeTo(response.writer)
             return
         }

--- a/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/CatalogueElementPrintHelper.groovy
+++ b/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/CatalogueElementPrintHelper.groovy
@@ -3,6 +3,7 @@ package org.modelcatalogue.core.xml
 import grails.gorm.DetachedCriteria
 import org.modelcatalogue.core.*
 import org.modelcatalogue.core.api.ElementStatus
+import org.modelcatalogue.core.util.HibernateHelper
 
 abstract class CatalogueElementPrintHelper<E extends CatalogueElement> {
 
@@ -33,19 +34,19 @@ abstract class CatalogueElementPrintHelper<E extends CatalogueElement> {
     }
 
     static void printElement(theMkp, CatalogueElement element, PrintContext context, Relationship rel, String elementName = null) {
-        CatalogueElementPrintHelper helper = get(element.class)
+        CatalogueElementPrintHelper helper = get(HibernateHelper.getEntityClass(element))
         if (!elementName) {
             elementName = helper.topLevelName
         }
 
         if (element instanceof DataModel) {
-            if (context.currentClassification) {
+            if (context.currentDataModel) {
                 theMkp."${elementName}"(ref(element, context, true)) {
                     processRelationshipMetadata(theMkp, context, rel)
                 }
                 return
             }
-            context.currentClassification = element
+            context.currentDataModel = element
             context.typesUsed << 'declaration'
         }
 
@@ -62,8 +63,12 @@ abstract class CatalogueElementPrintHelper<E extends CatalogueElement> {
             helper.processElements(theMkp, element, context, rel)
         }
 
+        if (context.repetitive) {
+            context.removeFromPrinted(element)
+        }
+
         if (element instanceof DataModel) {
-            context.currentClassification = null
+            context.currentDataModel = null
         }
     }
 
@@ -71,7 +76,7 @@ abstract class CatalogueElementPrintHelper<E extends CatalogueElement> {
     Map<String, Object> collectAttributes(E element, PrintContext context) {
         Map<String, Object> attrs = [name: element.name]
 
-        if (element.dataModel && context.currentClassification != element.dataModel) {
+        if (element.dataModel && context.currentDataModel != element.dataModel) {
             attrs.dataModel = element.dataModel.name
         }
 
@@ -188,13 +193,13 @@ abstract class CatalogueElementPrintHelper<E extends CatalogueElement> {
 
         if (element.dataModel) {
             if (includeDefaultId) {
-                if (context.currentClassification == element.dataModel) {
+                if (context.currentDataModel == element.dataModel) {
                     return [name: element.name, id: element.getDefaultModelCatalogueId(context.idIncludeVersion)]
                 } else {
                     return [name: element.name, dataModel: element.dataModel.name, id: element.getDefaultModelCatalogueId(context.idIncludeVersion)]
                 }
             }
-            if (context.currentClassification == element.dataModel) {
+            if (context.currentDataModel == element.dataModel) {
                 return [name: element.name]
             } else {
                 return [name: element.name, dataModel: element.dataModel.name]

--- a/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/PrintContext.groovy
+++ b/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/PrintContext.groovy
@@ -12,8 +12,9 @@ class PrintContext {
 
     boolean idIncludeVersion
     boolean noHref
+    boolean repetitive
 
-    DataModel currentClassification
+    DataModel currentDataModel
     DataModel keepInside
     Set<Long> idsOfPrinted = []
 
@@ -27,6 +28,10 @@ class PrintContext {
 
     void markAsPrinted(CatalogueElement element) {
         idsOfPrinted << element.id
+    }
+
+    void removeFromPrinted(CatalogueElement element) {
+        idsOfPrinted - element.id
     }
 
     boolean wasPrinted(CatalogueElement element) {

--- a/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/PrintContext.groovy
+++ b/ModelCatalogueCorePluginTestApp/src/groovy/org/modelcatalogue/core/xml/PrintContext.groovy
@@ -31,7 +31,7 @@ class PrintContext {
     }
 
     void removeFromPrinted(CatalogueElement element) {
-        idsOfPrinted - element.id
+        idsOfPrinted.remove(element.id)
     }
 
     boolean wasPrinted(CatalogueElement element) {


### PR DESCRIPTION
it will only print references if any of the parent elements was already printed to prevent infinite loops but the elements are printed again even if they were printed in other branch of the xml tree