### PR TITLE
MET-1527 cleaned up data model policies view

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/mc/core/ui/templates/catalogueElementView.tpl.html
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/mc/core/ui/templates/catalogueElementView.tpl.html
@@ -12,10 +12,10 @@
                 title="{{getDeprecationWarning()}}">
           </span>
           <span editable-text="copy.name" e-name="name">{{element.name}}</span>
-          <small class="text-muted" editable-text="copy.modelCatalogueId" e-name="modelCatalogueId">
+          <small class="text-muted" editable-text="copy.modelCatalogueId" e-name="modelCatalogueId" ng-if="element.getVersionAndId()">
               {{element.getVersionAndId()}}
           </small>
-          <small>
+          <small ng-if="element.getDataModelWithVersion()">
             <a ng-href="{{element.dataModel.href()}}"
                class="label"
                ng-class="{

--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/catalogueElementEnhancer.coffee
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/catalogueElementEnhancer.coffee
@@ -179,8 +179,7 @@ angular.module('mc.core.catalogueElementEnhancer', ['ui.router', 'mc.util.rest',
               semver = @semanticVersion
               versionNumber = @versionNumber
             else
-              ret = 'None'
-              semver = '0.0.0'
+              return null
 
             semver = "rev#{versionNumber}" unless semver
 
@@ -205,6 +204,7 @@ angular.module('mc.core.catalogueElementEnhancer', ['ui.router', 'mc.util.rest',
             return semver
 
           self.getVersionAndId = ->
+            return null unless @getExternalId()
             "#{@getExternalId()}@#{@getSemanticVersion()}"
 
           self.getExternalId = ->

--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/catalogueElementActions.coffee
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/catalogueElementActions.coffee
@@ -168,13 +168,12 @@ angular.module('mc.core.ui.bs.catalogueElementActions', ['mc.util.ui.actions']).
       return undefined if not angular.isFunction $scope.element.isInstanceOf
 
     {
-      show:       true
       position:   0
       label:      names.getNaturalName(names.getPropertyNameFromQualifier($scope.element.elementType))
       icon:       catalogue.getIcon($scope.element.elementType)
       type:       'primary'
       watches:    ['element.elementType', 'element.status']
-      expandToLeft: true
+      abstract:   true
     }
   ]
 

--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/catalogueElementProperties.coffee
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/bs/catalogueElementProperties.coffee
@@ -242,6 +242,7 @@ angular.module('mc.core.ui.bs.catalogueElementProperties', []).config ['catalogu
   catalogueElementPropertiesProvider.configureProperty 'internalModelCatalogueId', hidden: true
   catalogueElementPropertiesProvider.configureProperty 'versionNumber', hidden: true
   catalogueElementPropertiesProvider.configureProperty 'isTaggedBy', hidden: true
+  catalogueElementPropertiesProvider.configureProperty '__enhance__promise__', hidden: true
 
   catalogueElementPropertiesProvider.configureProperty '$$relationship', tabDefinition: [ '$element', '$name', ($element, $name) ->
 

--- a/ModelCatalogueCorePluginTestApp/test/js/modelcatalogue/core/ui/bs/catalogueElementTreeviewItem.spec.coffee
+++ b/ModelCatalogueCorePluginTestApp/test/js/modelcatalogue/core/ui/bs/catalogueElementTreeviewItem.spec.coffee
@@ -24,7 +24,7 @@ describe "mc.core.ui.catalogueElementTreeviewItem", ->
 
     expect(element.prop('tagName').toLowerCase()).toBe('li')
     expect(element.find('span.catalogue-element-treeview-name').text().replace(/^\s+|\s+$/g, '').replace(/\s\s+/g, ' '))
-      .toBe("#{catEl.name} None 0.0.0")
+      .toBe(catEl.name)
     expect(element.find('span.badge').text().replace(/^\s+|\s+$/g, '').replace(/\s\s+/g, ' ')).toBe("#{catEl.outgoingRelationships.total}")
 
 


### PR DESCRIPTION
Disabled showing the version and the data model (aka the tag) in the catalogue element view (the catalogue element detail page). Hidden `__enhance__promise__ ` property which is a helper property attached to several JavaScript objects.