### PR TITLE
MET 2161

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataModel.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataModel.groovy
@@ -47,10 +47,11 @@ class DataModel extends CatalogueElement {
         def manualDelete = declares.collectEntries {
             // check the element for the same - if manual delete is needed
             def relationshipManualDelete = it.manualDeleteRelationships(this)
-            if (relationshipManualDelete.size() > 0)
+            if (relationshipManualDelete.size() > 0) {
                 return [(it): relationshipManualDelete]
-            else
+            } else {
                 return [:]
+            }
         }
         // inspect relationships
         manualDelete << (outgoingRelationships + incomingRelationships).collectEntries {

--- a/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataType.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataType.groovy
@@ -40,10 +40,11 @@ class DataType extends CatalogueElement implements Validating {
         DataElement.findAllByDataType(this).collectEntries {
             if (toBeDeleted) {
                 // if DataModel is going to be deleted, then DataElement needs to be from same DataModel
-                if (it.dataModel != this.dataModel)
+                if (it.dataModel != this.dataModel) {
                     return [(it): it.dataModel]
-                else
+                } else {
                     return [:]
+                }
             } else {
                 // if deletes DataType, it should not be used anywhere
                 return [(it): null]

--- a/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataType.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/DataType.groovy
@@ -43,7 +43,7 @@ class DataType extends CatalogueElement implements Validating {
                 if (it.dataModel != this.dataModel) {
                     return [(it): it.dataModel]
                 } else {
-                    return [:]
+                    return [(it): null]
                 }
             } else {
                 // if deletes DataType, it should not be used anywhere

--- a/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/MeasurementUnit.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/MeasurementUnit.groovy
@@ -22,7 +22,7 @@ class MeasurementUnit extends CatalogueElement {
                 if (it.dataModel != this.dataModel) {
                     return [(it): it.dataModel]
                 } else {
-                    return [:]
+                    return [(it): null]
                 }
             } else {
                 // if deletes MeasurementUnit, it should not be used anywhere

--- a/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/MeasurementUnit.groovy
+++ b/ModelCatalogueCorePluginTestApp/grails-app/domain/org/modelcatalogue/core/MeasurementUnit.groovy
@@ -19,10 +19,11 @@ class MeasurementUnit extends CatalogueElement {
         primitiveTypes.collectEntries {
             if (toBeDeleted) {
                 // if DataModel is going to be deleted, then MeasurementUnit needs to be from same DataModel
-                if (it.dataModel != this.dataModel)
+                if (it.dataModel != this.dataModel) {
                     return [(it): it.dataModel]
-                else
+                } else {
                     return [:]
+                }
             } else {
                 // if deletes MeasurementUnit, it should not be used anywhere
                 return [(it): null]


### PR DESCRIPTION
Fixes https://metadata.atlassian.net/browse/MET-2161

returning the primitive type in manualDeleteRelationship in the MeasurementUnit.groovy causes the UI to warn the user that we cannot remove the Measurement Unit until he has removed the relationships first. 

<img width="651" alt="napkin 7 11-01-18 1 01 06 pm" src="https://user-images.githubusercontent.com/864788/34824598-7d65cdb8-f6cf-11e7-92cc-b536091828f5.png">
