### PR TITLE
Fix FinalizedDataModelIsMarkedAsFinalizedInXMLSpec

### DIFF
--- a/ModelCatalogueCorePluginTestApp/test/functional/GebConfig.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/GebConfig.groovy
@@ -5,6 +5,8 @@
 */
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.remote.DesiredCapabilities
+import org.openqa.selenium.remote.CapabilityType
 
 waiting {
     timeout = 2
@@ -15,7 +17,22 @@ environments {
     // run via “./gradlew chromeTest”
     // See: http://code.google.com/p/selenium/wiki/ChromeDriver
     chrome {
-        driver = { new ChromeDriver() }
+        String downloadFilepath = "/home/vijay/"
+        System.setProperty("downloadFilepath", downloadFilepath)
+        HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
+        chromePrefs.put("profile.default_content_settings.popups", 0);
+        chromePrefs.put("download.default_directory", downloadFilepath);
+
+        ChromeOptions options = new ChromeOptions();
+        options.setExperimentalOption("prefs", chromePrefs);
+        options.addArguments("--test-type");
+        options.addArguments("--disable-extensions"); //to disable browser extension popup
+
+        DesiredCapabilities cap = DesiredCapabilities.chrome();
+        cap.setCapability(ChromeOptions.CAPABILITY, options);
+        cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
+
+        driver = { new ChromeDriver(cap) }
     }
 
     // run via “./gradlew chromeHeadlessTest”
@@ -30,6 +47,7 @@ environments {
 
 }
 
+
+
 baseNavigatorWaiting = true
 atCheckWaiting = true
-

--- a/ModelCatalogueCorePluginTestApp/test/functional/GebConfig.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/GebConfig.groovy
@@ -17,22 +17,25 @@ environments {
     // run via “./gradlew chromeTest”
     // See: http://code.google.com/p/selenium/wiki/ChromeDriver
     chrome {
-        String downloadFilepath = "/home/vijay/"
-        System.setProperty("downloadFilepath", downloadFilepath)
-        HashMap<String, Object> chromePrefs = new HashMap<String, Object>();
-        chromePrefs.put("profile.default_content_settings.popups", 0);
-        chromePrefs.put("download.default_directory", downloadFilepath);
+        if (System.getProperty('downloadFilepath')) {
+            String downloadFilepath = System.getProperty('downloadFilepath')
+            HashMap<String, Object> chromePrefs = new HashMap<String, Object>()
+            chromePrefs.put("profile.default_content_settings.popups", 0)
+            chromePrefs.put("download.default_directory", downloadFilepath)
 
-        ChromeOptions options = new ChromeOptions();
-        options.setExperimentalOption("prefs", chromePrefs);
-        options.addArguments("--test-type");
-        options.addArguments("--disable-extensions"); //to disable browser extension popup
+            ChromeOptions options = new ChromeOptions()
+            options.setExperimentalOption("prefs", chromePrefs)
+            options.addArguments("--test-type")
+            options.addArguments("--disable-extensions") //to disable browser extension popup
 
-        DesiredCapabilities cap = DesiredCapabilities.chrome();
-        cap.setCapability(ChromeOptions.CAPABILITY, options);
-        cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
+            DesiredCapabilities cap = DesiredCapabilities.chrome()
+            cap.setCapability(ChromeOptions.CAPABILITY, options)
+            cap.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true)
 
-        driver = { new ChromeDriver(cap) }
+            driver = { new ChromeDriver(cap) }
+        } else {
+            driver = { new ChromeDriver() }
+        }
     }
 
     // run via “./gradlew chromeHeadlessTest”
@@ -46,8 +49,6 @@ environments {
     }
 
 }
-
-
 
 baseNavigatorWaiting = true
 atCheckWaiting = true

--- a/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/geb/DataModelPage.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/geb/DataModelPage.groovy
@@ -28,10 +28,15 @@ class DataModelPage extends Page {
         dropdownLink(required: false) { $('a#role_item_catalogue-element-menu-item-link', 0) }
         dropdown(required: false) { $('li#role_item_catalogue-element-menu-item').module(DataModelNavModule) }
         exportLink(required: false) { $('a#role_item_export-menu-item-link') }
+        exportXMLLink(required: false) { $('a#catalogue-element-export-specific-reports_12-menu-item-link') }
     }
 
     void isExportVisible() {
         !exportLink.empty
+    }
+
+    void exportXml() {
+        exportXMLLink.click()
     }
 
     void export() {

--- a/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
@@ -10,6 +10,7 @@ import spock.lang.Issue
 import org.modelcatalogue.core.geb.CatalogueAction
 import spock.lang.Narrative
 import spock.lang.Title
+import groovy.io.FileType
 
 @Issue('https://metadata.atlassian.net/browse/MET-1561')
 @Title('Examine that finalized data model is marked as finalized in the XML')
@@ -23,6 +24,10 @@ import spock.lang.Title
 class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
 
     def 'Examine that finalized data model is marked as finalized in the XML'() {
+
+        given:
+        String dataModelName = "Cancer Model"
+
         when: 'login as a curator'
         LoginPage loginPage = to LoginPage
         loginPage.login('curator', 'curator')
@@ -32,7 +37,7 @@ class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
 
         when: 'Select a Finalized Model'
         DashboardPage dashboardPage = browser.page DashboardPage
-        dashboardPage.select('Cancer Model')
+        dashboardPage.select(dataModelName)
 
         then:
         at DataModelPage
@@ -42,5 +47,28 @@ class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
 
         then:
         dataModelPage.isExportVisible()
+
+        when:
+        List<String> files = []
+        String downloadPath = System.getProperty("downloadFilepath")
+
+        File file = new File(downloadPath)
+        File cancelFile = new File(downloadPath + "Cancer_Model.mc.xml")
+
+        if (cancelFile.exists()) {
+            cancelFile.delete()
+        }
+
+        dataModelPage.export()
+        dataModelPage.exportXml()
+        Thread.sleep(2000)
+
+        file.eachFile(FileType.FILES) {
+            files.add(it.name)
+        }
+
+        then:
+        files.contains("Cancer_Model.mc.xml")
+        cancelFile.text.contains(dataModelName)
     }
 }

--- a/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
@@ -11,6 +11,7 @@ import org.modelcatalogue.core.geb.CatalogueAction
 import spock.lang.Narrative
 import spock.lang.Title
 import groovy.io.FileType
+import spock.lang.IgnoreIf
 
 @Issue('https://metadata.atlassian.net/browse/MET-1561')
 @Title('Examine that finalized data model is marked as finalized in the XML')
@@ -21,6 +22,8 @@ import groovy.io.FileType
 - Scroll down and click on the Export to catalogue XML
 - Open the downloaded file and verify that the status is marked as finalized
 ''')
+
+@IgnoreIf({ !System.getProperty("downloadFilepath") })
 class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
 
     def 'Examine that finalized data model is marked as finalized in the XML'() {
@@ -70,5 +73,7 @@ class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
         then:
         files.contains("Cancer_Model.mc.xml")
         cancelFile.text.contains(dataModelName)
+        String compareString = 'status="FINALIZED"'
+        cancelFile.text.toLowerCase().contains(compareString.toLowerCase())
     }
 }

--- a/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/functional/org/modelcatalogue/core/remoteTesting/FinalizedDataModelIsMarkedAsFinalizedInXMLSpec.groovy
@@ -54,26 +54,37 @@ class FinalizedDataModelIsMarkedAsFinalizedInXMLSpec extends GebSpec {
         when:
         List<String> files = []
         String downloadPath = System.getProperty("downloadFilepath")
-
         File file = new File(downloadPath)
-        File cancelFile = new File(downloadPath + "Cancer_Model.mc.xml")
-
-        if (cancelFile.exists()) {
-            cancelFile.delete()
-        }
-
-        dataModelPage.export()
-        dataModelPage.exportXml()
-        Thread.sleep(2000)
-
-        file.eachFile(FileType.FILES) {
-            files.add(it.name)
-        }
 
         then:
-        files.contains("Cancer_Model.mc.xml")
-        cancelFile.text.contains(dataModelName)
-        String compareString = 'status="FINALIZED"'
-        cancelFile.text.toLowerCase().contains(compareString.toLowerCase())
+        file.exists()
+
+        and:
+        file.isDirectory()
+
+        when:
+        String path = downloadPath + File.separator + "Cancer_Model.mc.xml"
+        File dataModelFile = new File(path)
+
+        then:
+        !dataModelFile.exists()
+
+        when:
+        dataModelPage.export()
+        dataModelPage.exportXml()
+        sleep(2_000)
+        dataModelFile = new File(path)
+
+        then:
+        dataModelFile.exists()
+
+        and:
+        dataModelFile.text.contains(dataModelName)
+
+        and:
+        dataModelFile.text.toLowerCase().contains('status="FINALIZED"'.toLowerCase())
+
+        cleanup:
+        dataModelFile.delete()
     }
 }


### PR DESCRIPTION
Download the XML of the finalized data model and check the downloaded XML has the finalized data model name. Changes are three files:
**GebConfig**: Added the configuration to download the file and save it a location  
**DataModelPage**: Added the download link.  
**FinalizedDataModelIsMarkedAsFinalizedInXMLSpec**: Testing file
