### PR TITLE
This fixes the headers issue with the infinite table that is used for…

### DIFF
--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/infiniteTable.coffee
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/modelcatalogue/core/ui/infiniteTable.coffee
@@ -19,7 +19,7 @@ angular.module('mc.core.ui.infiniteTable', ['mc.core.ui.infiniteListCtrl', 'mc.c
 
       header = $element.find('.inf-table-header')
       body   = $element.find('.inf-table-body')
-      spacer = $element.find('.inf-table-spacer')
+#      spacer = $element.find('.inf-table-spacer')
 
 
       windowEl = angular.element($window)

--- a/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/templates/mc/core/ui/infiniteTable.tpl.html
+++ b/ModelCatalogueCorePluginTestApp/grails-app/assets/javascripts/templates/mc/core/ui/infiniteTable.tpl.html
@@ -1,9 +1,9 @@
 <div>
-  <div class="inf-table-header">
-    <table class="inf-table table">
+  <div class="inf-table-header inf-table-body">
+    <table class="inf-table table" ng-class="{'table-expand': manualLoad && total != elements.length && elements.length > 0}">
       <thead>
       <tr>
-        <td colspan="2" class="col-md-12">
+        <td colspan="2">
           <span class="pull-right text-muted" ng-if="total != 0"><em>{{elements.length}} of {{total}}</em></span>
           <span class="pull-right text-muted" ng-if="total == 0"><em>Empty</em></span>
         </td>
@@ -23,13 +23,6 @@
         </th>
       </tr>
       </thead>
-    </table>
-  </div>
-  <div class="inf-table-spacer">
-  </div>
-  <div class="inf-table-body">
-    <table class="inf-table table"
-           ng-class="{'table-expand': manualLoad && total != elements.length && elements.length > 0}">
       <tbody ng-if="rows" sortable="sortableOptions">
       <tr class="inf-table-item-row" ng-repeat-start="row in rows" ng-class="row.classesForStatus">
         <td class="inf-table-item-cell" ng-class="row.head.classes" ng-switch="row.head.type">


### PR DESCRIPTION
… most of the grids. There is now just one table and the Bootstrap grid class in the first colspanned header row has been removed. The other grid classes have been retained as they do set the column widths (even though they are designed for the Bootstrap grid system, not tables).