### PR TITLE
fix unit tests

### DIFF
--- a/ModelCatalogueCorePluginTestApp/test/unit/org/modelcatalogue/core/util/marshalling/CatalogueElementMarshallersSpec.groovy
+++ b/ModelCatalogueCorePluginTestApp/test/unit/org/modelcatalogue/core/util/marshalling/CatalogueElementMarshallersSpec.groovy
@@ -17,7 +17,7 @@ class CatalogueElementMarshallersSpec extends Specification {
             findRelationshipTypes() >> []
         }
 
-        def relationships = marshallers.getRelationshipConfiguration(DataElement)
+        def relationships = marshallers.relationshipTypeService.getRelationshipConfiguration(DataElement)
 
         expect:
         relationships.incoming


### PR DESCRIPTION
fix CatalogueElementMarshallersSpec– had failed due to me moving getRelationshipConfiguration method from CatalogueElementMarshaller to RelationshipTypeService.